### PR TITLE
update to test-unit 3.x compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ system.
 
 ## Supported versions
 
-The latest release of Test::Unit 2.5 is supported.
+The latest release of Test::Unit 3.1 is supported.
 
 ## Installation
 

--- a/ci_reporter_test_unit.gemspec
+++ b/ci_reporter_test_unit.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features|acceptance)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "test-unit", "~> 2.5.5"
+  spec.add_dependency "test-unit", ">= 2.5.5", "< 4.0"
   spec.add_dependency "ci_reporter", "~> 2.0"
 
   spec.add_development_dependency "bundler", "~> 1.6"


### PR DESCRIPTION
test-unit 3.x is 100% backwards compatible and doesn't introduce any
additionally interesting features for our purposes here.

the effective version requirement is now >= 2.5.5 and < 4.0 as to allow
all 3.x versions in addition to what was required before.