### PR TITLE
Omitted tests should be reported as <skipped>

### DIFF
--- a/acceptance/test_unit_example_test.rb
+++ b/acceptance/test_unit_example_test.rb
@@ -14,4 +14,7 @@ class TestUnitExampleTestTwo < Test::Unit::TestCase
   def test_two
     assert true
   end
+  def test_three
+    omit 'omitted'
+  end
 end

--- a/acceptance/verification_spec.rb
+++ b/acceptance/verification_spec.rb
@@ -36,10 +36,15 @@ describe "Test::Unit acceptance" do
 
     it { is_expected.to have(0).errors }
     it { is_expected.to have(0).failures }
-    it { is_expected.to have(1).testcases }
+    it { is_expected.to have(2).testcases }
 
     describe "the assertion count" do
       subject { result.assertions_count }
+      it { is_expected.to eql 1 }
+    end    
+
+    describe "the skipped count" do
+      subject { result.skipped_count}
       it { is_expected.to eql 1 }
     end
 

--- a/lib/ci/reporter/test_unit.rb
+++ b/lib/ci/reporter/test_unit.rb
@@ -31,6 +31,7 @@ module CI
       def initialize(fault) @fault = fault end
       def failure?() false end
       def error?() true end
+      def skipped?() false end
       def name() @fault.exception.class.name end
       def message() @fault.exception.message end
       def location() @fault.exception.backtrace.join("\n") end
@@ -41,6 +42,7 @@ module CI
       def initialize(fault) @fault = fault end
       def failure?() true end
       def error?() false end
+      def skipped?() false end
       def name() Test::Unit::AssertionFailedError.name end
       def message() @fault.message end
       def location() @fault.location.join("\n") end
@@ -51,6 +53,7 @@ module CI
       def initialize(fault) @fault = fault end
       def failure?() false end
       def error?() false end
+      def skipped?() true end
       def name() @fault.class.name end
       def message() @fault.message end
       def location() @fault.location.join("\n") end
@@ -61,6 +64,7 @@ module CI
       def initialize(fault) @fault = fault end
       def failure?() false end
       def error?() false end
+      def skipped?() false end
       def name() @fault.class.name end
       def message() @fault.message end
       def location() @fault.location.join("\n") end
@@ -103,7 +107,9 @@ module CI
 
       def fault(fault)
         tc = @current_suite.testcases.last
-        tc.failures << Failure.new(fault)
+        f = Failure.new(fault)
+        tc.failures << f 
+        tc.skipped=true if f.skipped? 
       end
 
       def finished(elapsed_time)


### PR DESCRIPTION
Following test

```
def test_omit    
  omit 'omitted'
end
```
is reported as

```
<testcase name="test_omit" time="0.000373181" assertions="0">
    <failure type="Test::Unit::Omission" message="omitted">...</failure>
</testcase>
```
but it should be reported as `<skipped>` instead of `<failure>`

Simple fix is to set up `skipped` flag ci-reporter's `TestCase` which was not used in ci_reporter_test_unit yet